### PR TITLE
Adding the NaN handling logic. 

### DIFF
--- a/espnet2/train/lightning_espnet_model.py
+++ b/espnet2/train/lightning_espnet_model.py
@@ -7,6 +7,7 @@ from espnet2.tasks.abs_task import optim_classes, scheduler_classes
 from espnet2.tasks.asr import ASRTask
 from espnet2.train.distributed_utils import DistributedOption
 from espnet2.utils.yaml_no_alias_safe_dump import yaml_no_alias_safe_dump
+import logging
 
 task_choices = {
     "asr": ASRTask,
@@ -28,12 +29,56 @@ class LitESPnetModel(L.LightningModule):
             ) as f:
                 yaml_no_alias_safe_dump(vars(args), f, indent=4, sort_keys=False)
 
+    def _sync2skip(self, flag_skip):
+        # see https://github.com/Lightning-AI/lightning/issues/5243#issuecomment-1552650013
+        # gathering a tensor across all workers and then reduce it using or
+        world_size = torch_dist.get_world_size()
+        torch_dist.barrier()
+        # now gather
+        result = [torch.zeros_like(flag_skip) for _ in range(world_size)]
+        torch_dist.all_gather(result, flag_skip)
+        any_invalid = torch.sum(torch.stack(result)).bool().item()
+        return any_invalid
+
+    def _check_nan_inf_loss(self, loss, batch_id):
+
+        mask_nan_inf = torch.logical_or(torch.isnan(loss), ~torch.isfinite(loss))
+        if torch.any(mask_nan_inf):
+            # if any is invalid then we must flag this to all DDP processes
+            flag_skip = torch.ones((), device=loss.device, dtype=torch.bool)
+        else:
+            flag_skip = torch.zeros((), device=loss.device, dtype=torch.bool)
+
+        # sub-optimal but will do,
+        # till they fix it in https://github.com/Lightning-AI/lightning/issues/5243#issuecomment-1552650013
+        any_invalid = self._sync2skip(flag_skip)
+        if any_invalid:
+            if self.nan_countdown >= 100:
+                raise RuntimeError(
+                    "Too many NaNs loss iterations encountered, stopping !"
+                )
+            logging.warning(
+                f"NaN loss in batch {batch_id} of epoch {self.current_epoch}, "
+                f"skipping the whole batch across all workers."
+            )
+            self.nan_countdown += 1
+        else:
+            # reset counter
+            self.nan_countdown = 1
+
+        return any_invalid
+
     def _step(self, batch, batch_idx, mode):
         utt_id, batch = batch
         batch["utt_id"] = utt_id
 
         # loss is averaged over samples within a mini-batch; weight is batch size
         loss, stats, weight = self.model(**batch)
+
+        any_invalid = self._check_nan_inf_loss(loss, batch_idx)
+        if any_invalid:
+            # skip this batch altogether on all workers.
+            return None
 
         new_stats = {}
         for k, v in stats.items():


### PR DESCRIPTION
Note that whole training iteration is skipped. 
I think this is ok as you don't want to affect the training dynamics maybe. 
It is much more complicated to only skip the worker that caused problems. 