### PR TITLE
Enhance the efficiency of large-scale training

### DIFF
--- a/espnet2/asr/decoder/transformer_decoder.py
+++ b/espnet2/asr/decoder/transformer_decoder.py
@@ -4,6 +4,7 @@
 """Decoder definition."""
 from typing import Any, List, Sequence, Tuple
 
+import logging
 import torch
 from typeguard import typechecked
 
@@ -63,6 +64,7 @@ class BaseTransformerDecoder(
         use_output_layer: bool = True,
         pos_enc_class=PositionalEncoding,
         normalize_before: bool = True,
+        gradient_checkpoint_layers: List[int] = [],
     ):
         super().__init__()
         attention_dim = encoder_output_size
@@ -95,6 +97,10 @@ class BaseTransformerDecoder(
         # Must set by the inheritance
         self.decoders = None
         self.batch_ids = None
+
+        # For gradient checkpointing, start from 1 (not 0)
+        self.gradient_checkpoint_layers = gradient_checkpoint_layers
+        logging.info(f"Gradient checkpoint layers: {self.gradient_checkpoint_layers}")
 
     def forward(
         self,
@@ -147,9 +153,15 @@ class BaseTransformerDecoder(
         x = self.embed(tgt)
         intermediate_outs = []
         for layer_idx, decoder_layer in enumerate(self.decoders):
-            x, tgt_mask, memory, memory_mask = decoder_layer(
-                x, tgt_mask, memory, memory_mask
-            )
+            if layer_idx + 1 in self.gradient_checkpoint_layers:
+                x, tgt_mask, memory, memory_mask = torch.utils.checkpoint.checkpoint(
+                    decoder_layer, x, tgt_mask, memory, memory_mask,
+                    use_reentrant=False
+                )
+            else:
+                x, tgt_mask, memory, memory_mask = decoder_layer(
+                    x, tgt_mask, memory, memory_mask
+                )
             if return_all_hs:
                 intermediate_outs.append(x)
         if self.normalize_before:
@@ -389,6 +401,7 @@ class TransformerDecoder(BaseTransformerDecoder):
         layer_drop_rate: float = 0.0,
         qk_norm: bool = False,
         use_flash_attn: bool = True,
+        gradient_checkpoint_layers: List[int] = [],
     ):
         super().__init__(
             vocab_size=vocab_size,
@@ -399,6 +412,7 @@ class TransformerDecoder(BaseTransformerDecoder):
             use_output_layer=use_output_layer,
             pos_enc_class=pos_enc_class,
             normalize_before=normalize_before,
+            gradient_checkpoint_layers=gradient_checkpoint_layers,
         )
 
         if use_flash_attn:

--- a/espnet2/asr/encoder/e_branchformer_encoder.py
+++ b/espnet2/asr/encoder/e_branchformer_encoder.py
@@ -10,7 +10,7 @@ Reference:
 """
 
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import torch
 from typeguard import typechecked
@@ -216,6 +216,7 @@ class EBranchformerEncoder(AbsEncoder):
         interctc_use_conditioning: bool = False,
         qk_norm: bool = False,
         use_flash_attn: bool = True,
+        gradient_checkpoint_layers: List[int] = [],
     ):
         super().__init__()
         self._output_size = output_size
@@ -435,6 +436,11 @@ class EBranchformerEncoder(AbsEncoder):
         self.interctc_use_conditioning = interctc_use_conditioning
         self.conditioning_layer = None
 
+        # For gradient checkpointing
+        # 0 is the embedding layer, 1 is the first encoder layer, etc.
+        self.gradient_checkpoint_layers = gradient_checkpoint_layers
+        logging.info(f"Gradient checkpoint layers: {self.gradient_checkpoint_layers}")
+
     def output_size(self) -> int:
         return self._output_size
 
@@ -480,40 +486,62 @@ class EBranchformerEncoder(AbsEncoder):
                     xs_pad.size(1),
                     limit_size,
                 )
-            xs_pad, masks = self.embed(xs_pad, masks)
+            if 0 in self.gradient_checkpoint_layers:
+                xs_pad, masks = torch.utils.checkpoint.checkpoint(
+                    self.embed, xs_pad, masks,
+                    use_reentrant=False
+                )
+            else:
+                xs_pad, masks = self.embed(xs_pad, masks)
         elif self.embed is not None:
-            xs_pad = self.embed(xs_pad)
+            if 0 in self.gradient_checkpoint_layers:
+                xs_pad = torch.utils.checkpoint.checkpoint(
+                    self.embed, xs_pad,
+                    use_reentrant=False
+                )
+            else:
+                xs_pad = self.embed(xs_pad)
+
+        # if len(self.interctc_layer_idx) == 0:
+        #     if max_layer is not None and 0 <= max_layer < len(self.encoders):
+        #         for layer_idx, encoder_layer in enumerate(self.encoders):
+        #             xs_pad, masks = encoder_layer(xs_pad, masks)
+        #             if layer_idx >= max_layer:
+        #                 break
+        #     else:
+        #         xs_pad, masks = self.encoders(xs_pad, masks)
+        # else:
 
         intermediate_outs = []
-        if len(self.interctc_layer_idx) == 0:
-            if max_layer is not None and 0 <= max_layer < len(self.encoders):
-                for layer_idx, encoder_layer in enumerate(self.encoders):
-                    xs_pad, masks = encoder_layer(xs_pad, masks)
-                    if layer_idx >= max_layer:
-                        break
+        for layer_idx, encoder_layer in enumerate(self.encoders):
+            if max_layer is not None and layer_idx >= max_layer:
+                break
+
+            if layer_idx + 1 in self.gradient_checkpoint_layers:
+                xs_pad, masks = torch.utils.checkpoint.checkpoint(
+                    encoder_layer, xs_pad, masks,
+                    use_reentrant=False
+                )
             else:
-                xs_pad, masks = self.encoders(xs_pad, masks)
-        else:
-            for layer_idx, encoder_layer in enumerate(self.encoders):
                 xs_pad, masks = encoder_layer(xs_pad, masks)
 
-                if layer_idx + 1 in self.interctc_layer_idx:
-                    encoder_out = xs_pad
+            if layer_idx + 1 in self.interctc_layer_idx:
+                encoder_out = xs_pad
 
-                    if isinstance(encoder_out, tuple):
-                        encoder_out = encoder_out[0]
+                if isinstance(encoder_out, tuple):
+                    encoder_out = encoder_out[0]
 
-                    intermediate_outs.append((layer_idx + 1, encoder_out))
+                intermediate_outs.append((layer_idx + 1, encoder_out))
 
-                    if self.interctc_use_conditioning:
-                        ctc_out = ctc.softmax(encoder_out)
+                if self.interctc_use_conditioning:
+                    ctc_out = ctc.softmax(encoder_out)
 
-                        if isinstance(xs_pad, tuple):
-                            xs_pad = list(xs_pad)
-                            xs_pad[0] = xs_pad[0] + self.conditioning_layer(ctc_out)
-                            xs_pad = tuple(xs_pad)
-                        else:
-                            xs_pad = xs_pad + self.conditioning_layer(ctc_out)
+                    if isinstance(xs_pad, tuple):
+                        xs_pad = list(xs_pad)
+                        xs_pad[0] = xs_pad[0] + self.conditioning_layer(ctc_out)
+                        xs_pad = tuple(xs_pad)
+                    else:
+                        xs_pad = xs_pad + self.conditioning_layer(ctc_out)
 
         if isinstance(xs_pad, tuple):
             xs_pad = xs_pad[0]

--- a/espnet2/fileio/read_text.py
+++ b/espnet2/fileio/read_text.py
@@ -3,14 +3,19 @@ import logging
 from mmap import mmap
 from pathlib import Path
 from random import randint
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, Set
 
 from typeguard import typechecked
 
 
 @typechecked
-def read_2columns_text(path: Union[Path, str]) -> Dict[str, str]:
+def read_2columns_text(
+    path: Union[Path, str],
+    keys_to_load: Optional[Set[Union[str, int]]] = None,
+) -> Dict[str, str]:
     """Read a text file having 2 columns as dict object.
+
+    Only load the keys in keys_to_load if it is not None.
 
     Examples:
         wav.scp:
@@ -22,6 +27,12 @@ def read_2columns_text(path: Union[Path, str]) -> Dict[str, str]:
 
     """
 
+    if keys_to_load is not None:
+        logging.info(
+            f"keys_to_load is not None, only loading {len(keys_to_load)} keys "
+            f"from {path}"
+        )
+
     data = {}
     with Path(path).open("r", encoding="utf-8") as f:
         for linenum, line in enumerate(f, 1):
@@ -30,6 +41,9 @@ def read_2columns_text(path: Union[Path, str]) -> Dict[str, str]:
                 k, v = sps[0], ""
             else:
                 k, v = sps
+
+            if keys_to_load is not None and k not in keys_to_load:
+                continue
 
             if k in data:
                 raise RuntimeError(f"{k} is duplicated ({path}:{linenum})")

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -2,6 +2,7 @@
 
 import argparse
 import functools
+import itertools
 import logging
 import os
 import sys
@@ -9,7 +10,7 @@ import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import humanfriendly
 import numpy as np
@@ -1761,10 +1762,12 @@ class AbsTask(ABC):
 
     @classmethod
     @typechecked
-    def build_sequence_iter_factory(
-        cls, args: argparse.Namespace, iter_options: IteratorOptions, mode: str
-    ) -> AbsIterFactory:
-
+    def build_dataset(
+        cls,
+        args: argparse.Namespace,
+        iter_options: IteratorOptions,
+        keys_to_load: Optional[Set[Union[int, str]]] = None,
+    ) -> AbsDataset:
         if args.multi_task_dataset:
             dataset_class = ESPnetMultiTaskDataset
         else:
@@ -1777,20 +1780,22 @@ class AbsTask(ABC):
             max_cache_size=iter_options.max_cache_size,
             max_cache_fd=iter_options.max_cache_fd,
             allow_multi_rates=iter_options.allow_multi_rates,
+            keys_to_load=keys_to_load,
         )
         cls.check_task_requirements(
             dataset, args.allow_variable_data_keys, train=iter_options.train
         )
+        return dataset
 
-        if Path(
-            Path(iter_options.data_path_and_name_and_type[0][0]).parent, "utt2category"
-        ).exists():
-            utt2category_file = str(
-                Path(
-                    Path(iter_options.data_path_and_name_and_type[0][0]).parent,
-                    "utt2category",
-                )
-            )
+    @classmethod
+    @typechecked
+    def build_sequence_iter_factory(
+        cls, args: argparse.Namespace, iter_options: IteratorOptions, mode: str
+    ) -> AbsIterFactory:
+
+        utt2category_file = Path(iter_options.data_path_and_name_and_type[0][0]).parent / "utt2category"
+        if utt2category_file.exists():
+            utt2category_file = str(utt2category_file)
             logging.warning("Reading " + utt2category_file)
         else:
             utt2category_file = None
@@ -1816,13 +1821,13 @@ class AbsTask(ABC):
 
         bs_list = [len(batch) for batch in batches]
 
-        logging.info(f"[{mode}] dataset:\n{dataset}")
         logging.info(f"[{mode}] Batch sampler: {batch_sampler}")
         logging.info(
             f"[{mode}] mini-batch sizes summary: N-batch={len(bs_list)}, "
             f"mean={np.mean(bs_list):.1f}, min={np.min(bs_list)}, max={np.max(bs_list)}"
         )
 
+        # Shard mini-batches for distributed training
         if iter_options.distributed:
             world_size = torch.distributed.get_world_size()
             rank = torch.distributed.get_rank()
@@ -1833,6 +1838,15 @@ class AbsTask(ABC):
                         f"{len(batch)} < {world_size}"
                     )
             batches = [batch[rank::world_size] for batch in batches]
+
+        # Build dataset after sharding to reduce memory usage
+        # This is very helpful for large-scale training
+        dataset = cls.build_dataset(
+            args,
+            iter_options,
+            set(itertools.chain(*batches)),
+        )
+        logging.info(f"[{mode}] dataset:\n{dataset}")
 
         return SequenceIterFactory(
             dataset=dataset,

--- a/espnet2/tasks/abs_task.py
+++ b/espnet2/tasks/abs_task.py
@@ -461,6 +461,20 @@ class AbsTask(ABC):
             type=str,
             help="deepspeed training config",
         )
+        group.add_argument(
+            "--gradient_as_bucket_view",
+            default=True,
+            type=str2bool,
+            help="Enable gradient_as_bucket_view in DDP",
+        )
+        group.add_argument(
+            "--ddp_comm_hook",
+            default=None,
+            type=str_or_none,
+            choices=["none", "fp16_compress_hook", "bf16_compress_hook"],
+            help="DDP communication hook from "
+            "torch.distributed.algorithms.ddp_comm_hooks.default_hooks",
+        )
 
         group = parser.add_argument_group("cudnn mode related")
         group.add_argument(

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -104,7 +104,8 @@ class TrainerOptions:
     unused_parameters: bool
     wandb_model_log_interval: int
     create_graph_in_tensorboard: bool
-
+    gradient_as_bucket_view: bool
+    ddp_comm_hook: Optional[str]
 
 class Trainer:
     """Trainer having a optimizer.
@@ -268,7 +269,24 @@ class Trainer:
                         else None
                     ),
                     find_unused_parameters=trainer_options.unused_parameters,
+                    gradient_as_bucket_view=trainer_options.gradient_as_bucket_view,
                 )
+
+                # Register DDP communication hook
+                if trainer_options.ddp_comm_hook is not None:
+                    import torch.distributed.algorithms.ddp_comm_hooks.default_hooks
+                    dp_model.register_comm_hook(
+                        None, 
+                        getattr(
+                            torch.distributed.algorithms.ddp_comm_hooks.default_hooks,
+                            trainer_options.ddp_comm_hook
+                        )
+                    )
+                    logging.info(
+                        f"Registered DDP communication hook: "
+                        f"{trainer_options.ddp_comm_hook}"
+                    )
+
         elif distributed_option.ngpu > 1:
             dp_model = torch.nn.parallel.DataParallel(
                 model,
@@ -313,6 +331,7 @@ class Trainer:
 
             reporter.set_epoch(iepoch)
             # 1. Train and validation for one-epoch
+            torch.cuda.empty_cache()
             with reporter.observe("train") as sub_reporter:
                 all_steps_are_invalid = cls.train_one_epoch(
                     model=dp_model,
@@ -326,6 +345,7 @@ class Trainer:
                     distributed_option=distributed_option,
                 )
 
+            torch.cuda.empty_cache()
             with reporter.observe("valid") as sub_reporter:
                 cls.validate_one_epoch(
                     model=dp_model,
@@ -334,6 +354,8 @@ class Trainer:
                     options=trainer_options,
                     distributed_option=distributed_option,
                 )
+
+            torch.cuda.empty_cache()
             if not distributed_option.distributed or distributed_option.dist_rank == 0:
                 # att_plot doesn't support distributed
                 if plot_attention_iter_factory is not None:
@@ -648,6 +670,8 @@ class Trainer:
                         loss, stats, weight = retval
                         optim_idx = None
 
+                    retval = None
+
                 stats = {k: v for k, v in stats.items() if v is not None}
                 if ngpu > 1 or distributed:
                     # Apply weighted averaging for loss and stats
@@ -822,7 +846,12 @@ class Trainer:
             if no_forward_run:
                 continue
 
-            retval = model(**batch)
+            with autocast(
+                options.use_amp,
+                **autocast_args,
+            ):
+                retval = model(**batch)
+
             if isinstance(retval, dict):
                 stats = retval["stats"]
                 weight = retval["weight"]

--- a/espnet2/train/trainer.py
+++ b/espnet2/train/trainer.py
@@ -274,13 +274,14 @@ class Trainer:
 
                 # Register DDP communication hook
                 if trainer_options.ddp_comm_hook is not None:
-                    import torch.distributed.algorithms.ddp_comm_hooks.default_hooks
+                    from torch.distributed.algorithms.ddp_comm_hooks.default_hooks import fp16_compress_hook, bf16_compress_hook
+                    _hooks = {
+                        "fp16_compress_hook": fp16_compress_hook,
+                        "bf16_compress_hook": bf16_compress_hook,
+                    }
                     dp_model.register_comm_hook(
                         None, 
-                        getattr(
-                            torch.distributed.algorithms.ddp_comm_hooks.default_hooks,
-                            trainer_options.ddp_comm_hook
-                        )
+                        _hooks[trainer_options.ddp_comm_hook],
                     )
                     logging.info(
                         f"Registered DDP communication hook: "


### PR DESCRIPTION
## What?

This PR aims to improve the (memory) efficiency of large-scale training.

- **[Major change]** Implement efficient dataset creation, where only samples belonging to this process are loaded. In distributed training, each process only keeps a fraction of samples, thus significantly reducing memory usage. With this technique, we usually no longer need to split the training set.
- Fix interface compatibility of the latest versions of `flash-attn`
- Enable `amp` for validation
- Support `gradient_as_bucket_view` and `comm_hook` in DDP for better efficiency
- Support gradient/activation checkpointing in encoder/decoder for better efficiency
